### PR TITLE
feat: add qjsc command

### DIFF
--- a/lib/export_dart.js
+++ b/lib/export_dart.js
@@ -1,0 +1,12 @@
+module.exports = function(buffer) {
+
+  let uint8Array = Uint8Array.from(buffer);
+
+  return `
+import 'dart:typed_data';
+
+Uint8List byteData = Uint8List.fromList([
+  ${uint8Array.join(',')}
+]);
+  `;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openkraken/cli",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -595,8 +595,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       },
@@ -604,9 +602,7 @@
         "file-uri-to-path": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-          "dev": true,
-          "optional": true
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         }
       }
     },
@@ -2961,9 +2957,7 @@
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3016,6 +3010,11 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-addon-api": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3494,6 +3493,24 @@
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
+        }
+      }
+    },
+    "qjsc": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/qjsc/-/qjsc-0.2.4.tgz",
+      "integrity": "sha512-271vJUY6YPAvGGHxSVeYVcPFkbWoiGjb4uuBShSySGxAmAQUDjkj7BXDpjAS4dTsAXGscYvPB8kc1PlqBmrGmA==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "commander": "^8.2.0",
+        "nan": "^2.15.0",
+        "node-addon-api": "^4.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   ],
   "author": "Kraken Team",
   "dependencies": {
+    "chalk": "^2.4.2",
     "commander": "^4.0.1",
-    "temp": "^0.9.1",
-    "chalk": "^2.4.2"
+    "qjsc": "^0.2.4",
+    "temp": "^0.9.1"
   },
   "devDependencies": {
     "ali-oss": "^6.5.1",


### PR DESCRIPTION
添加 kraken qjsc 命令，支持将一个 js 文件转换成 bytecode。

生成一个 dart 文件
```bash
kraken qjsc ./lib/websocket.js ./lib/websocket_qjsc.dart --dart
```

生成 kbc 文件
```
kraken qjsc ./lib/websocket.js ./lib/websocket.kbc1
```