### PR TITLE
fix: install failed when directory contains spaces

### DIFF
--- a/install.js
+++ b/install.js
@@ -6,11 +6,13 @@ const packageJSON = require('./package.json');
 const tarName = `kraken-${os.platform()}-${packageJSON.version}.tar.gz`;
 const downloadUrl = `https://kraken.oss-cn-hangzhou.aliyuncs.com/kraken-cli-vendors/${tarName}`;
 
+const wrapPath = (path) => path.replace(/ /g, "\\ ");
+
 const processOptions = {
-  cwd: __dirname,
+  cwd: wrapPath(__dirname),
   stdio: 'inherit'
 };
 execSync(`curl -O ${downloadUrl}`, processOptions);
 execSync('mkdir -p build', processOptions);
-execSync(`tar xzf ${path.join(__dirname, tarName).replace(/ /g, "\\ ")} -C ./build`, processOptions);
+execSync(`tar xzf ${wrapPath(path.join(__dirname, tarName))} -C ./build`, processOptions);
 execSync(`rm ${tarName}`, processOptions);


### PR DESCRIPTION
## Error
```
Error: Command failed: tar xzf /Users/xxx/Library/Application Support/fnm/node-versions/v18.0.0/installation/lib/node_modules/@openkraken/cli/kraken-darwin-0.10.5.tar.gz -C ./build
```

## Reason
In my case, the file directory contains spaces. And you can't execute that command with space.
```
execSync(`tar xzf ${path.join(__dirname, tarName)} -C ./build`, processOptions);
```